### PR TITLE
fixed HTTP response code of createMessage endpoint

### DIFF
--- a/public-specs/Messaging/openapispec.json
+++ b/public-specs/Messaging/openapispec.json
@@ -332,7 +332,7 @@
                     "required": false
                 },
                 "responses": {
-                    "200": {
+                    "202": {
                         "description": "successful operation",
                         "headers": {},
                         "content": {


### PR DESCRIPTION
According to [the API documentation](https://dev.bandwidth.com/messaging/methods/messages/createMessage.html) and also in reality this endpoint returns:

```
Status: 202 Accepted
Content-Type: application/json; charset=utf-8
```